### PR TITLE
feat : report, signal 조회 api 추가, report 누적 생성

### DIFF
--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/controller/SignalController.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/controller/SignalController.java
@@ -1,9 +1,11 @@
 package com.seo92js.news_alpha_backend.domain.signal.controller;
 
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalDetailResponse;
 import com.seo92js.news_alpha_backend.domain.signal.dto.SignalResponse;
 import com.seo92js.news_alpha_backend.domain.signal.service.SignalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +21,10 @@ public class SignalController {
     @GetMapping
     public List<SignalResponse> findRecentSignals() {
         return signalService.findRecentSignals();
+    }
+
+    @GetMapping("/{signalId}")
+    public SignalDetailResponse findSignalDetail(@PathVariable Long signalId) {
+        return signalService.findSignalDetail(signalId);
     }
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalDetailResponse.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalDetailResponse.java
@@ -5,7 +5,7 @@ import com.seo92js.news_alpha_backend.domain.signal.SignalType;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record SignalResponse(
+public record SignalDetailResponse(
         Long id,
         String keyword,
         SignalType type,
@@ -16,10 +16,10 @@ public record SignalResponse(
         LocalDateTime firstPublishedAt,
         LocalDateTime lastPublishedAt,
         LocalDateTime detectedAt,
-        List<SignalEvidenceResponse> evidences
+        List<SignalEvidenceDetailResponse> evidences
 ) {
-    public static SignalResponse from(SignalView signal, List<SignalEvidenceResponse> evidences) {
-        return new SignalResponse(
+    public static SignalDetailResponse from(SignalView signal, List<SignalEvidenceDetailResponse> evidences) {
+        return new SignalDetailResponse(
                 signal.id(),
                 signal.keyword(),
                 signal.type(),

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceDetailResponse.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceDetailResponse.java
@@ -1,0 +1,39 @@
+package com.seo92js.news_alpha_backend.domain.signal.dto;
+
+import java.time.LocalDateTime;
+
+public record SignalEvidenceDetailResponse(
+        Long newsId,
+        int rankOrder,
+        String title,
+        String url,
+        LocalDateTime publishedAt,
+        String preview
+) {
+    public static SignalEvidenceDetailResponse from(SignalEvidenceDetailRow evidence) {
+        return new SignalEvidenceDetailResponse(
+                evidence.newsId(),
+                evidence.rankOrder(),
+                evidence.title(),
+                evidence.url(),
+                evidence.publishedAt(),
+                buildPreview(evidence.description(), evidence.content())
+        );
+    }
+
+    private static String buildPreview(String description, String content) {
+        String source = description;
+        if (content != null && !content.isBlank()) {
+            source = content;
+        }
+        if (source == null || source.isBlank()) {
+            return null;
+        }
+
+        String normalized = source.replaceAll("\\s+", " ").trim();
+        if (normalized.length() <= 220) {
+            return normalized;
+        }
+        return normalized.substring(0, 220) + "...";
+    }
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceDetailRow.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceDetailRow.java
@@ -1,0 +1,14 @@
+package com.seo92js.news_alpha_backend.domain.signal.dto;
+
+import java.time.LocalDateTime;
+
+public record SignalEvidenceDetailRow(
+        Long newsId,
+        int rankOrder,
+        String title,
+        String url,
+        LocalDateTime publishedAt,
+        String description,
+        String content
+) {
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceResponse.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceResponse.java
@@ -1,7 +1,5 @@
 package com.seo92js.news_alpha_backend.domain.signal.dto;
 
-import com.seo92js.news_alpha_backend.domain.signal.SignalEvidence;
-
 import java.time.LocalDateTime;
 
 public record SignalEvidenceResponse(
@@ -11,13 +9,13 @@ public record SignalEvidenceResponse(
         String url,
         LocalDateTime publishedAt
 ) {
-    public static SignalEvidenceResponse from(SignalEvidence evidence) {
+    public static SignalEvidenceResponse from(SignalEvidenceRow evidence) {
         return new SignalEvidenceResponse(
-                evidence.getNewsId(),
-                evidence.getRankOrder(),
-                evidence.getTitle(),
-                evidence.getUrl(),
-                evidence.getPublishedAt()
+                evidence.newsId(),
+                evidence.rankOrder(),
+                evidence.title(),
+                evidence.url(),
+                evidence.publishedAt()
         );
     }
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceRow.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalEvidenceRow.java
@@ -1,0 +1,13 @@
+package com.seo92js.news_alpha_backend.domain.signal.dto;
+
+import java.time.LocalDateTime;
+
+public record SignalEvidenceRow(
+        Long signalId,
+        Long newsId,
+        int rankOrder,
+        String title,
+        String url,
+        LocalDateTime publishedAt
+) {
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalView.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/dto/SignalView.java
@@ -1,0 +1,19 @@
+package com.seo92js.news_alpha_backend.domain.signal.dto;
+
+import com.seo92js.news_alpha_backend.domain.signal.SignalType;
+
+import java.time.LocalDateTime;
+
+public record SignalView(
+        Long id,
+        String keyword,
+        SignalType type,
+        String title,
+        String summary,
+        double score,
+        int relatedNewsCount,
+        LocalDateTime firstPublishedAt,
+        LocalDateTime lastPublishedAt,
+        LocalDateTime detectedAt
+) {
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalEvidenceRepository.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalEvidenceRepository.java
@@ -3,8 +3,5 @@ package com.seo92js.news_alpha_backend.domain.signal.repository;
 import com.seo92js.news_alpha_backend.domain.signal.SignalEvidence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-public interface SignalEvidenceRepository extends JpaRepository<SignalEvidence, Long> {
-    List<SignalEvidence> findBySignalIdOrderByRankOrderAsc(Long signalId);
+public interface SignalEvidenceRepository extends JpaRepository<SignalEvidence, Long>, SignalEvidenceRepositoryCustom {
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalEvidenceRepositoryCustom.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalEvidenceRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.seo92js.news_alpha_backend.domain.signal.repository;
+
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceDetailRow;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceRow;
+
+import java.util.List;
+
+public interface SignalEvidenceRepositoryCustom {
+    List<SignalEvidenceRow> findEvidenceRowsBySignalIds(List<Long> signalIds);
+    List<SignalEvidenceDetailRow> findEvidenceDetailRowsBySignalId(Long signalId);
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalEvidenceRepositoryImpl.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalEvidenceRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.seo92js.news_alpha_backend.domain.signal.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceDetailRow;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceRow;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.seo92js.news_alpha_backend.domain.news.QNews.news;
+import static com.seo92js.news_alpha_backend.domain.signal.QSignalEvidence.signalEvidence;
+
+@RequiredArgsConstructor
+public class SignalEvidenceRepositoryImpl implements SignalEvidenceRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SignalEvidenceRow> findEvidenceRowsBySignalIds(List<Long> signalIds) {
+        if (signalIds == null || signalIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        SignalEvidenceRow.class,
+                        signalEvidence.signal.id,
+                        signalEvidence.newsId,
+                        signalEvidence.rankOrder,
+                        signalEvidence.title,
+                        signalEvidence.url,
+                        signalEvidence.publishedAt
+                ))
+                .from(signalEvidence)
+                .where(signalEvidence.signal.id.in(signalIds))
+                .orderBy(signalEvidence.signal.id.asc(), signalEvidence.rankOrder.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<SignalEvidenceDetailRow> findEvidenceDetailRowsBySignalId(Long signalId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        SignalEvidenceDetailRow.class,
+                        signalEvidence.newsId,
+                        signalEvidence.rankOrder,
+                        signalEvidence.title,
+                        signalEvidence.url,
+                        signalEvidence.publishedAt,
+                        news.description,
+                        news.content
+                ))
+                .from(signalEvidence)
+                .leftJoin(news).on(news.id.eq(signalEvidence.newsId))
+                .where(signalEvidence.signal.id.eq(signalId))
+                .orderBy(signalEvidence.rankOrder.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalRepositoryCustom.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.seo92js.news_alpha_backend.domain.signal.repository;
 
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalView;
 import com.seo92js.news_alpha_backend.domain.signal.Signal;
 import org.springframework.data.domain.Pageable;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface SignalRepositoryCustom {
     List<Signal> findRecentSignalsByStockId(Long stockId, LocalDateTime since, Pageable pageable);
+    List<SignalView> findTopRecentSignalViews();
+    SignalView findSignalViewById(Long signalId);
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalRepositoryImpl.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/repository/SignalRepositoryImpl.java
@@ -1,32 +1,33 @@
 package com.seo92js.news_alpha_backend.domain.signal.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.seo92js.news_alpha_backend.domain.signal.QSignal;
-import com.seo92js.news_alpha_backend.domain.signal.QSignalEvidence;
 import com.seo92js.news_alpha_backend.domain.signal.Signal;
-import com.seo92js.news_alpha_backend.domain.stock.QNewsStock;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.seo92js.news_alpha_backend.domain.signal.QSignal.signal;
+import static com.seo92js.news_alpha_backend.domain.signal.QSignalEvidence.signalEvidence;
+import static com.seo92js.news_alpha_backend.domain.stock.QNewsStock.newsStock;
+
 @RequiredArgsConstructor
 public class SignalRepositoryImpl implements SignalRepositoryCustom {
+
+    private static final int MAX_RECENT_SIGNAL_VIEWS = 5;
 
     private final JPAQueryFactory queryFactory;
 
     @Override
     public List<Signal> findRecentSignalsByStockId(Long stockId, LocalDateTime since, Pageable pageable) {
-        QSignal signal = QSignal.signal;
-        QSignalEvidence evidence = QSignalEvidence.signalEvidence;
-        QNewsStock newsStock = QNewsStock.newsStock;
-
         return queryFactory
                 .selectDistinct(signal)
                 .from(signal)
-                .join(evidence).on(evidence.signal.eq(signal))
-                .join(newsStock).on(newsStock.news.id.eq(evidence.newsId))
+                .join(signalEvidence).on(signalEvidence.signal.eq(signal))
+                .join(newsStock).on(newsStock.news.id.eq(signalEvidence.newsId))
                 .where(
                         newsStock.stock.id.eq(stockId),
                         signal.detectedAt.goe(since)
@@ -35,5 +36,48 @@ public class SignalRepositoryImpl implements SignalRepositoryCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+    }
+
+    @Override
+    public List<SignalView> findTopRecentSignalViews() {
+        return queryFactory
+                .select(Projections.constructor(
+                        SignalView.class,
+                        signal.id,
+                        signal.keyword,
+                        signal.type,
+                        signal.title,
+                        signal.summary,
+                        signal.score,
+                        signal.relatedNewsCount,
+                        signal.firstPublishedAt,
+                        signal.lastPublishedAt,
+                        signal.detectedAt
+                ))
+                .from(signal)
+                .orderBy(signal.score.desc(), signal.detectedAt.desc())
+                .limit(MAX_RECENT_SIGNAL_VIEWS)
+                .fetch();
+    }
+
+    @Override
+    public SignalView findSignalViewById(Long signalId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        SignalView.class,
+                        signal.id,
+                        signal.keyword,
+                        signal.type,
+                        signal.title,
+                        signal.summary,
+                        signal.score,
+                        signal.relatedNewsCount,
+                        signal.firstPublishedAt,
+                        signal.lastPublishedAt,
+                        signal.detectedAt
+                ))
+                .from(signal)
+                .where(signal.id.eq(signalId))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/signal/service/SignalService.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/signal/service/SignalService.java
@@ -1,7 +1,12 @@
 package com.seo92js.news_alpha_backend.domain.signal.service;
 
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceRow;
 import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceResponse;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalDetailResponse;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceDetailRow;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceDetailResponse;
 import com.seo92js.news_alpha_backend.domain.signal.dto.SignalResponse;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalView;
 import com.seo92js.news_alpha_backend.domain.signal.repository.SignalEvidenceRepository;
 import com.seo92js.news_alpha_backend.domain.signal.repository.SignalRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +27,41 @@ public class SignalService {
      */
     @Transactional(readOnly = true)
     public List<SignalResponse> findRecentSignals() {
-        return signalRepository.findTop20ByOrderByScoreDescDetectedAtDesc().stream()
+        List<SignalView> signals = signalRepository.findTopRecentSignalViews();
+        List<SignalEvidenceRow> evidenceRows = signalEvidenceRepository.findEvidenceRowsBySignalIds(
+                signals.stream().map(SignalView::id).toList()
+        );
+
+        return signals.stream()
                 .map(signal -> SignalResponse.from(
                         signal,
-                        signalEvidenceRepository.findBySignalIdOrderByRankOrderAsc(signal.getId()).stream()
-                                .map(SignalEvidenceResponse::from)
-                                .toList()
+                        buildEvidenceResponses(signal.id(), evidenceRows)
                 ))
+                .toList();
+    }
+
+    /**
+     * 특정 시그널의 요약 정보와 근거 뉴스 preview 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public SignalDetailResponse findSignalDetail(Long signalId) {
+        SignalView signal = signalRepository.findSignalViewById(signalId);
+        if (signal == null) {
+            return null;
+        }
+
+        return SignalDetailResponse.from(
+                signal,
+                signalEvidenceRepository.findEvidenceDetailRowsBySignalId(signalId).stream()
+                        .map(SignalEvidenceDetailResponse::from)
+                        .toList()
+        );
+    }
+
+    private List<SignalEvidenceResponse> buildEvidenceResponses(Long signalId, List<SignalEvidenceRow> evidenceRows) {
+        return evidenceRows.stream()
+                .filter(row -> row.signalId().equals(signalId))
+                .map(SignalEvidenceResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/StockReport.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/StockReport.java
@@ -12,11 +12,6 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_stock_report_stock_report_date", columnNames = {"stock_id", "report_date"})
-        }
-)
 public class StockReport extends BaseEntity {
 
     @Id
@@ -47,11 +42,5 @@ public class StockReport extends BaseEntity {
         stockReport.report = report;
         stockReport.generatedAt = generatedAt;
         return stockReport;
-    }
-
-    public void update(int signalCount, String report, LocalDateTime generatedAt) {
-        this.signalCount = signalCount;
-        this.report = report;
-        this.generatedAt = generatedAt;
     }
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/StockReportSignal.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/StockReportSignal.java
@@ -1,0 +1,43 @@
+package com.seo92js.news_alpha_backend.domain.stock;
+
+import com.seo92js.news_alpha_backend.BaseEntity;
+import com.seo92js.news_alpha_backend.domain.signal.Signal;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_stock_report_signal_report_signal", columnNames = {"stock_report_id", "signal_id"}),
+                @UniqueConstraint(name = "uk_stock_report_signal_report_rank", columnNames = {"stock_report_id", "rank_order"})
+        }
+)
+public class StockReportSignal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_report_id", nullable = false)
+    private StockReport stockReport;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "signal_id", nullable = false)
+    private Signal signal;
+
+    @Column(name = "rank_order", nullable = false)
+    private int rankOrder;
+
+    public static StockReportSignal of(StockReport stockReport, Signal signal, int rankOrder) {
+        StockReportSignal stockReportSignal = new StockReportSignal();
+        stockReportSignal.stockReport = stockReport;
+        stockReportSignal.signal = signal;
+        stockReportSignal.rankOrder = rankOrder;
+        return stockReportSignal;
+    }
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/controller/StockController.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/controller/StockController.java
@@ -39,6 +39,11 @@ public class StockController {
         return stockService.findKeywords(stockId);
     }
 
+    @GetMapping("/{stockId}/report/latest")
+    public StockLatestReportResponse findLatestReport(@PathVariable Long stockId) {
+        return stockService.findLatestReport(stockId);
+    }
+
     @GetMapping("/meta")
     public List<StockMetaResponse> findAllMeta() {
         return krxStockService.findAll();

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/dto/StockLatestReportResponse.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/dto/StockLatestReportResponse.java
@@ -1,0 +1,33 @@
+package com.seo92js.news_alpha_backend.domain.stock.dto;
+
+import com.seo92js.news_alpha_backend.domain.stock.StockReport;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record StockLatestReportResponse(
+        Long stockId,
+        String stockName,
+        String ticker,
+        String market,
+        LocalDate reportDate,
+        int signalCount,
+        String report,
+        LocalDateTime generatedAt,
+        List<StockSignalSummaryResponse> signals
+) {
+    public static StockLatestReportResponse from(StockReport stockReport, List<StockSignalSummaryResponse> signals) {
+        return new StockLatestReportResponse(
+                stockReport.getStock().getId(),
+                stockReport.getStock().getName(),
+                stockReport.getStock().getTicker(),
+                stockReport.getStock().getMarket(),
+                stockReport.getReportDate(),
+                stockReport.getSignalCount(),
+                stockReport.getReport(),
+                stockReport.getGeneratedAt(),
+                signals
+        );
+    }
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/dto/StockSignalSummaryResponse.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/dto/StockSignalSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.seo92js.news_alpha_backend.domain.stock.dto;
+
+import java.time.LocalDateTime;
+
+public record StockSignalSummaryResponse(
+        Long signalId,
+        String title,
+        String summary,
+        double score,
+        int relatedNewsCount,
+        LocalDateTime detectedAt
+) {
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockKeywordRepositoryImpl.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockKeywordRepositoryImpl.java
@@ -1,11 +1,12 @@
 package com.seo92js.news_alpha_backend.domain.stock.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.seo92js.news_alpha_backend.domain.stock.QStockKeyword;
 import com.seo92js.news_alpha_backend.domain.stock.StockKeyword;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+
+import static com.seo92js.news_alpha_backend.domain.stock.QStockKeyword.stockKeyword;
 
 @RequiredArgsConstructor
 public class StockKeywordRepositoryImpl implements StockKeywordRepositoryCustom {
@@ -14,8 +15,6 @@ public class StockKeywordRepositoryImpl implements StockKeywordRepositoryCustom 
 
     @Override
     public List<StockKeyword> findEnabledWithStock() {
-        QStockKeyword stockKeyword = QStockKeyword.stockKeyword;
-
         return queryFactory
                 .selectFrom(stockKeyword)
                 .join(stockKeyword.stock).fetchJoin()

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepository.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepository.java
@@ -3,10 +3,8 @@ package com.seo92js.news_alpha_backend.domain.stock.repository;
 import com.seo92js.news_alpha_backend.domain.stock.StockReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 public interface StockReportRepository extends JpaRepository<StockReport, Long> {
-    Optional<StockReport> findByStockIdAndReportDate(Long stockId, LocalDate reportDate);
     Optional<StockReport> findTopByStockIdOrderByGeneratedAtDesc(Long stockId);
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepository.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepository.java
@@ -1,0 +1,7 @@
+package com.seo92js.news_alpha_backend.domain.stock.repository;
+
+import com.seo92js.news_alpha_backend.domain.stock.StockReportSignal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockReportSignalRepository extends JpaRepository<StockReportSignal, Long>, StockReportSignalRepositoryCustom {
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryCustom.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.seo92js.news_alpha_backend.domain.stock.repository;
+
+import com.seo92js.news_alpha_backend.domain.stock.dto.StockSignalSummaryResponse;
+
+import java.util.List;
+
+public interface StockReportSignalRepositoryCustom {
+    List<StockSignalSummaryResponse> findSignalSummariesByStockReportId(Long stockReportId);
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryImpl.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.seo92js.news_alpha_backend.domain.stock.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seo92js.news_alpha_backend.domain.stock.dto.StockSignalSummaryResponse;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.seo92js.news_alpha_backend.domain.signal.QSignal.signal;
+import static com.seo92js.news_alpha_backend.domain.stock.QStockReportSignal.stockReportSignal;
+
+@RequiredArgsConstructor
+public class StockReportSignalRepositoryImpl implements StockReportSignalRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StockSignalSummaryResponse> findSignalSummariesByStockReportId(Long stockReportId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        StockSignalSummaryResponse.class,
+                        signal.id,
+                        signal.title,
+                        signal.summary,
+                        signal.score,
+                        signal.relatedNewsCount,
+                        signal.detectedAt
+                ))
+                .from(stockReportSignal)
+                .join(stockReportSignal.signal, signal)
+                .where(stockReportSignal.stockReport.id.eq(stockReportId))
+                .orderBy(stockReportSignal.rankOrder.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/service/StockReportService.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/service/StockReportService.java
@@ -5,7 +5,9 @@ import com.seo92js.news_alpha_backend.domain.signal.Signal;
 import com.seo92js.news_alpha_backend.domain.signal.repository.SignalRepository;
 import com.seo92js.news_alpha_backend.domain.stock.Stock;
 import com.seo92js.news_alpha_backend.domain.stock.StockReport;
+import com.seo92js.news_alpha_backend.domain.stock.StockReportSignal;
 import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportRepository;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportSignalRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.prompt.PromptTemplate;
@@ -21,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Slf4j
 @Service
@@ -28,14 +31,12 @@ import java.util.stream.Collectors;
 public class StockReportService {
 
     /**
-     * 종목 리포트에 반영할 최대 시그널 수
-     * 너무 많으면 LLM 입력이 길어지고 리포트 초점이 흐려져 상위 5개만 사용
+     * 종목 리포트 생성 시 반영할 최대 시그널 수
      */
     private static final int MAX_SIGNALS = 5;
 
     /**
-     * 종목 리포트 생성 시 참고할 시그널 조회 기간
-     * 현재는 오늘 투자 판단에 필요한 최근 24시간 흐름을 기준으로 함
+     * 종목 리포트 생성 시 참고할 최근 시그널 조회 기간
      */
     private static final int SIGNAL_LOOKBACK_HOURS = 24;
 
@@ -47,12 +48,13 @@ public class StockReportService {
     private final AiService aiService;
     private final SignalRepository signalRepository;
     private final StockReportRepository stockReportRepository;
+    private final StockReportSignalRepository stockReportSignalRepository;
 
     @Value("classpath:/prompts/stock-report.st")
     private Resource stockReportPromptResource;
 
     /**
-     * 종목에 연결된 최근 시그널들을 모아 종목별 종합 리포트를 생성하거나 갱신
+     * 종목에 연결된 최근 시그널들을 모아 종목별 종합 리포트 스냅샷을 새로 생성
      */
     @Transactional
     public void generateLatestReport(Stock stock) {
@@ -67,15 +69,24 @@ public class StockReportService {
         }
 
         try {
-            LocalDate reportDate = LocalDate.now();
+            LocalDateTime generatedAt = LocalDateTime.now();
+            LocalDate reportDate = generatedAt.toLocalDate();
             String report = aiService.chat(buildPrompt(stock, reportDate, signals));
-            StockReport stockReport = stockReportRepository.findByStockIdAndReportDate(stock.getId(), reportDate)
-                    .orElseGet(() -> StockReport.of(stock, reportDate, signals.size(), report, LocalDateTime.now()));
-            stockReport.update(signals.size(), report, LocalDateTime.now());
-            stockReportRepository.save(stockReport);
+            StockReport savedStockReport = stockReportRepository.save(
+                    StockReport.of(stock, reportDate, signals.size(), report, generatedAt)
+            );
+            saveReportSignals(savedStockReport, signals);
         } catch (Exception e) {
             log.warn("종목 리포트 생성에 실패했습니다. stockId={}, stock={}", stock.getId(), stock.getName(), e);
         }
+    }
+
+    private void saveReportSignals(StockReport stockReport, List<Signal> signals) {
+        stockReportSignalRepository.saveAll(
+                IntStream.range(0, signals.size())
+                        .mapToObj(index -> StockReportSignal.of(stockReport, signals.get(index), index + 1))
+                        .toList()
+        );
     }
 
     private String buildPrompt(Stock stock, LocalDate reportDate, List<Signal> signals) {

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/service/StockService.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/service/StockService.java
@@ -4,12 +4,15 @@ import com.seo92js.news_alpha_backend.domain.stock.Stock;
 import com.seo92js.news_alpha_backend.domain.stock.StockKeyword;
 import com.seo92js.news_alpha_backend.domain.stock.dto.StockKeywordResponse;
 import com.seo92js.news_alpha_backend.domain.stock.dto.StockKeywordSaveRequest;
+import com.seo92js.news_alpha_backend.domain.stock.dto.StockLatestReportResponse;
 import com.seo92js.news_alpha_backend.domain.stock.dto.StockResponse;
 import com.seo92js.news_alpha_backend.domain.stock.dto.StockSaveRequest;
 import com.seo92js.news_alpha_backend.domain.stock.exception.DuplicateStockException;
 import com.seo92js.news_alpha_backend.domain.stock.exception.DuplicateStockKeywordException;
 import com.seo92js.news_alpha_backend.domain.stock.exception.StockNotFoundException;
 import com.seo92js.news_alpha_backend.domain.stock.repository.StockKeywordRepository;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportRepository;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportSignalRepository;
 import com.seo92js.news_alpha_backend.domain.stock.repository.StockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +26,8 @@ public class StockService {
 
     private final StockRepository stockRepository;
     private final StockKeywordRepository stockKeywordRepository;
+    private final StockReportRepository stockReportRepository;
+    private final StockReportSignalRepository stockReportSignalRepository;
 
     /**
      * 종목 저장
@@ -72,6 +77,23 @@ public class StockService {
             throw new StockNotFoundException(stockId);
         }
         return findKeywordResponses(stockId);
+    }
+
+    /**
+     * 특정 종목의 가장 최근 생성된 리포트 1건 조회
+     */
+    @Transactional(readOnly = true)
+    public StockLatestReportResponse findLatestReport(Long stockId) {
+        if (!stockRepository.existsById(stockId)) {
+            throw new StockNotFoundException(stockId);
+        }
+
+        return stockReportRepository.findTopByStockIdOrderByGeneratedAtDesc(stockId)
+                .map(stockReport -> StockLatestReportResponse.from(
+                        stockReport,
+                        stockReportSignalRepository.findSignalSummariesByStockReportId(stockReport.getId())
+                ))
+                .orElse(null);
     }
 
     private List<StockKeywordResponse> findKeywordResponses(Long stockId) {

--- a/src/test/java/com/seo92js/news_alpha_backend/domain/signal/service/SignalServiceTest.java
+++ b/src/test/java/com/seo92js/news_alpha_backend/domain/signal/service/SignalServiceTest.java
@@ -1,0 +1,110 @@
+package com.seo92js.news_alpha_backend.domain.signal.service;
+
+import com.seo92js.news_alpha_backend.domain.signal.SignalType;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalDetailResponse;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceDetailRow;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalEvidenceRow;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalResponse;
+import com.seo92js.news_alpha_backend.domain.signal.dto.SignalView;
+import com.seo92js.news_alpha_backend.domain.signal.repository.SignalEvidenceRepository;
+import com.seo92js.news_alpha_backend.domain.signal.repository.SignalRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SignalServiceTest {
+
+    @Mock
+    private SignalRepository signalRepository;
+
+    @Mock
+    private SignalEvidenceRepository signalEvidenceRepository;
+
+    @InjectMocks
+    private SignalService signalService;
+
+    @Test
+    void 최근_시그널_목록_조회시_signalId별로_근거뉴스_반환() {
+        SignalView first = new SignalView(
+                1L, "테슬라", SignalType.EMERGING_CLUSTER, "로보택시 기대감 재점화", "최근 기사 급증", 88.2, 6,
+                LocalDateTime.of(2026, 5, 7, 7, 0),
+                LocalDateTime.of(2026, 5, 7, 9, 0),
+                LocalDateTime.of(2026, 5, 7, 9, 10)
+        );
+        SignalView second = new SignalView(
+                2L, "테슬라", SignalType.EMERGING_CLUSTER, "일론 머스크 발언 영향", "변동성 확대", 81.5, 4,
+                LocalDateTime.of(2026, 5, 7, 6, 30),
+                LocalDateTime.of(2026, 5, 7, 8, 30),
+                LocalDateTime.of(2026, 5, 7, 8, 40)
+        );
+
+        when(signalRepository.findTopRecentSignalViews()).thenReturn(List.of(first, second));
+        when(signalEvidenceRepository.findEvidenceRowsBySignalIds(List.of(1L, 2L))).thenReturn(List.of(
+                new SignalEvidenceRow(1L, 101L, 1, "근거 기사 1", "https://a.com", LocalDateTime.of(2026, 5, 7, 9, 0)),
+                new SignalEvidenceRow(1L, 102L, 2, "근거 기사 2", "https://b.com", LocalDateTime.of(2026, 5, 7, 8, 50)),
+                new SignalEvidenceRow(2L, 201L, 1, "근거 기사 3", "https://c.com", LocalDateTime.of(2026, 5, 7, 8, 20))
+        ));
+
+        List<SignalResponse> responses = signalService.findRecentSignals();
+
+        assertEquals(2, responses.size());
+        assertEquals(2, responses.get(0).evidences().size());
+        assertEquals(1, responses.get(1).evidences().size());
+        assertEquals(101L, responses.get(0).evidences().get(0).newsId());
+        assertEquals(201L, responses.get(1).evidences().get(0).newsId());
+    }
+
+    @Test
+    void 시그널_상세_조회시_근거뉴스_반환() {
+        Long signalId = 1L;
+        SignalView signal = new SignalView(
+                signalId, "테슬라", SignalType.EMERGING_CLUSTER, "로보택시 기대감 재점화", "최근 기사 급증", 88.2, 6,
+                LocalDateTime.of(2026, 5, 7, 7, 0),
+                LocalDateTime.of(2026, 5, 7, 9, 0),
+                LocalDateTime.of(2026, 5, 7, 9, 10)
+        );
+        String content = "테슬라 로보택시 기대감이 시장에서 다시 부각되며 관련 뉴스가 빠르게 증가하고 있다. "
+                + "여러 매체가 같은 이슈를 반복 보도하면서 투자자 관심이 커지고 있다.";
+
+        when(signalRepository.findSignalViewById(signalId)).thenReturn(signal);
+        when(signalEvidenceRepository.findEvidenceDetailRowsBySignalId(signalId)).thenReturn(List.of(
+                new SignalEvidenceDetailRow(
+                        101L,
+                        1,
+                        "근거 기사 1",
+                        "https://a.com",
+                        LocalDateTime.of(2026, 5, 7, 9, 0),
+                        "짧은 설명",
+                        content
+                )
+        ));
+
+        SignalDetailResponse response = signalService.findSignalDetail(signalId);
+
+        assertNotNull(response);
+        assertEquals(signalId, response.id());
+        assertEquals(1, response.evidences().size());
+        assertNotNull(response.evidences().get(0).preview());
+        assertEquals(content, response.evidences().get(0).preview());
+    }
+
+    @Test
+    void 없는_시그널_상세_조회시_null반환() {
+        when(signalRepository.findSignalViewById(999L)).thenReturn(null);
+
+        SignalDetailResponse response = signalService.findSignalDetail(999L);
+
+        assertNull(response);
+    }
+}

--- a/src/test/java/com/seo92js/news_alpha_backend/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/com/seo92js/news_alpha_backend/domain/stock/service/StockServiceTest.java
@@ -1,0 +1,105 @@
+package com.seo92js.news_alpha_backend.domain.stock.service;
+
+import com.seo92js.news_alpha_backend.domain.stock.Stock;
+import com.seo92js.news_alpha_backend.domain.stock.StockReport;
+import com.seo92js.news_alpha_backend.domain.stock.dto.StockLatestReportResponse;
+import com.seo92js.news_alpha_backend.domain.stock.dto.StockSignalSummaryResponse;
+import com.seo92js.news_alpha_backend.domain.stock.exception.StockNotFoundException;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockKeywordRepository;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportRepository;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportSignalRepository;
+import com.seo92js.news_alpha_backend.domain.stock.repository.StockRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockServiceTest {
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private StockKeywordRepository stockKeywordRepository;
+
+    @Mock
+    private StockReportRepository stockReportRepository;
+
+    @Mock
+    private StockReportSignalRepository stockReportSignalRepository;
+
+    @InjectMocks
+    private StockService stockService;
+
+    @Test
+    void 최신_종목_리포트_조회시_핵심_시그널을_함께_반환한다() {
+        Long stockId = 1L;
+        Stock stock = Stock.of("TSLA", "테슬라", "NASDAQ");
+        ReflectionTestUtils.setField(stock, "id", stockId);
+
+        StockReport stockReport = StockReport.of(
+                stock,
+                LocalDate.of(2026, 5, 7),
+                2,
+                "테슬라 종합 리포트",
+                LocalDateTime.of(2026, 5, 7, 10, 30)
+        );
+
+        List<StockSignalSummaryResponse> signals = List.of(
+                new StockSignalSummaryResponse(101L, "로보택시 기대감 재점화", "최근 기사 급증", 88.2, 6, LocalDateTime.of(2026, 5, 7, 9, 0)),
+                new StockSignalSummaryResponse(102L, "일론 머스크 발언 영향", "변동성 확대", 81.5, 4, LocalDateTime.of(2026, 5, 7, 8, 30))
+        );
+
+        when(stockRepository.existsById(stockId)).thenReturn(true);
+        when(stockReportRepository.findTopByStockIdOrderByGeneratedAtDesc(stockId))
+                .thenReturn(Optional.of(stockReport));
+        when(stockReportSignalRepository.findSignalSummariesByStockReportId(stockReport.getId()))
+                .thenReturn(signals);
+
+        StockLatestReportResponse response = stockService.findLatestReport(stockId);
+
+        assertNotNull(response);
+        assertEquals(stockId, response.stockId());
+        assertEquals("테슬라", response.stockName());
+        assertEquals("테슬라 종합 리포트", response.report());
+        assertEquals(2, response.signals().size());
+        assertEquals(101L, response.signals().get(0).signalId());
+        verify(stockReportRepository).findTopByStockIdOrderByGeneratedAtDesc(stockId);
+    }
+
+    @Test
+    void 최신_종목_리포트가_없으면_null을_반환한다() {
+        Long stockId = 1L;
+
+        when(stockRepository.existsById(stockId)).thenReturn(true);
+        when(stockReportRepository.findTopByStockIdOrderByGeneratedAtDesc(stockId))
+                .thenReturn(Optional.empty());
+
+        StockLatestReportResponse response = stockService.findLatestReport(stockId);
+
+        assertNull(response);
+    }
+
+    @Test
+    void 존재하지_않는_종목의_리포트_조회시_예외가_발생한다() {
+        Long stockId = 999L;
+        when(stockRepository.existsById(stockId)).thenReturn(false);
+
+        assertThrows(StockNotFoundException.class, () -> stockService.findLatestReport(stockId));
+    }
+}


### PR DESCRIPTION
1. 프론트에서 종목별 리포트를 보여주고, 리포트 내 핵심 시그널을 클릭해 상세 내용을 확인하는 흐름을 지원하기 위해 아래 API 2종 추가
- 종목별 최신 Report 조회 API
- 시그널 상세 조회 API

2. 종복별 리포트 덮어쓰는 구조에서 개별 row 로 쌓이도록 수정
3. 리포트 <-> 시그널 매핑 테이블 추가

Close #30 