### PR TITLE
feat : 당일 리포트 조회 API 추가

### DIFF
--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/controller/StockController.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/controller/StockController.java
@@ -44,6 +44,11 @@ public class StockController {
         return stockService.findLatestReport(stockId);
     }
 
+    @GetMapping("/reports/latest")
+    public List<StockLatestReportResponse> findLatestReports() {
+        return stockService.findLatestReports();
+    }
+
     @GetMapping("/meta")
     public List<StockMetaResponse> findAllMeta() {
         return krxStockService.findAll();

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/dto/StockSignalSummaryResponse.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/dto/StockSignalSummaryResponse.java
@@ -6,6 +6,7 @@ import com.seo92js.news_alpha_backend.domain.signal.SignalSentiment;
 import java.time.LocalDateTime;
 
 public record StockSignalSummaryResponse(
+        Long stockReportId,
         Long signalId,
         String title,
         String summary,
@@ -20,6 +21,7 @@ public record StockSignalSummaryResponse(
         LocalDateTime detectedAt
 ) {
     public StockSignalSummaryResponse(
+            Long stockReportId,
             Long signalId,
             String title,
             String summary,
@@ -32,6 +34,7 @@ public record StockSignalSummaryResponse(
             LocalDateTime detectedAt
     ) {
         this(
+                stockReportId,
                 signalId,
                 title,
                 summary,

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepository.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface StockReportRepository extends JpaRepository<StockReport, Long> {
+public interface StockReportRepository extends JpaRepository<StockReport, Long>, StockReportRepositoryCustom {
     Optional<StockReport> findTopByStockIdOrderByGeneratedAtDesc(Long stockId);
     void deleteByStockId(Long stockId);
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepositoryCustom.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.seo92js.news_alpha_backend.domain.stock.repository;
+
+import com.seo92js.news_alpha_backend.domain.stock.StockReport;
+
+import java.util.List;
+
+public interface StockReportRepositoryCustom {
+    List<StockReport> findLatestStockReports();
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepositoryImpl.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.seo92js.news_alpha_backend.domain.stock.repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seo92js.news_alpha_backend.domain.stock.QStockReport;
+import com.seo92js.news_alpha_backend.domain.stock.StockReport;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.seo92js.news_alpha_backend.domain.stock.QStockReport.stockReport;
+
+@RequiredArgsConstructor
+public class StockReportRepositoryImpl implements StockReportRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StockReport> findLatestStockReports() {
+        QStockReport latestStockReport = new QStockReport("latestStockReport");
+        return queryFactory
+                .select(stockReport)
+                .from(stockReport)
+                .where(stockReport.generatedAt.eq(
+                        JPAExpressions.select(latestStockReport.generatedAt.max())
+                                .from(latestStockReport)
+                                .where(latestStockReport.stock.id.eq(stockReport.stock.id))
+                ))
+                .fetch();
+    }
+}

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryCustom.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface StockReportSignalRepositoryCustom {
     List<StockSignalSummaryResponse> findSignalSummariesByStockReportId(Long stockReportId);
+    List<StockSignalSummaryResponse> findSignalSummariesByStockReportIds(List<Long> stockReportIds);
 }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryImpl.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/repository/StockReportSignalRepositoryImpl.java
@@ -20,6 +20,7 @@ public class StockReportSignalRepositoryImpl implements StockReportSignalReposit
         return queryFactory
                 .select(Projections.constructor(
                         StockSignalSummaryResponse.class,
+                        stockReportSignal.stockReport.id,
                         signal.id,
                         signal.title,
                         signal.summary,
@@ -34,6 +35,30 @@ public class StockReportSignalRepositoryImpl implements StockReportSignalReposit
                 .from(stockReportSignal)
                 .join(stockReportSignal.signal, signal)
                 .where(stockReportSignal.stockReport.id.eq(stockReportId))
+                .orderBy(stockReportSignal.rankOrder.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<StockSignalSummaryResponse> findSignalSummariesByStockReportIds(List<Long> stockReportIds) {
+        return queryFactory
+                .select(Projections.constructor(
+                        StockSignalSummaryResponse.class,
+                        stockReportSignal.stockReport.id,
+                        signal.id,
+                        signal.title,
+                        signal.summary,
+                        signal.eventType,
+                        signal.sentiment,
+                        signal.confidence,
+                        signal.investorSummary,
+                        signal.score,
+                        signal.relatedNewsCount,
+                        signal.detectedAt
+                ))
+                .from(stockReportSignal)
+                .join(stockReportSignal.signal, signal)
+                .where(stockReportSignal.stockReport.id.in(stockReportIds))
                 .orderBy(stockReportSignal.rankOrder.asc())
                 .fetch();
     }

--- a/src/main/java/com/seo92js/news_alpha_backend/domain/stock/service/StockService.java
+++ b/src/main/java/com/seo92js/news_alpha_backend/domain/stock/service/StockService.java
@@ -1,17 +1,14 @@
 package com.seo92js.news_alpha_backend.domain.stock.service;
 
+import com.seo92js.news_alpha_backend.domain.signal.repository.SignalEvidenceRepository;
+import com.seo92js.news_alpha_backend.domain.signal.repository.SignalRepository;
 import com.seo92js.news_alpha_backend.domain.stock.Stock;
 import com.seo92js.news_alpha_backend.domain.stock.StockKeyword;
-import com.seo92js.news_alpha_backend.domain.stock.dto.StockKeywordResponse;
-import com.seo92js.news_alpha_backend.domain.stock.dto.StockKeywordSaveRequest;
-import com.seo92js.news_alpha_backend.domain.stock.dto.StockLatestReportResponse;
-import com.seo92js.news_alpha_backend.domain.stock.dto.StockResponse;
-import com.seo92js.news_alpha_backend.domain.stock.dto.StockSaveRequest;
+import com.seo92js.news_alpha_backend.domain.stock.StockReport;
+import com.seo92js.news_alpha_backend.domain.stock.dto.*;
 import com.seo92js.news_alpha_backend.domain.stock.exception.DuplicateStockException;
 import com.seo92js.news_alpha_backend.domain.stock.exception.DuplicateStockKeywordException;
 import com.seo92js.news_alpha_backend.domain.stock.exception.StockNotFoundException;
-import com.seo92js.news_alpha_backend.domain.signal.repository.SignalEvidenceRepository;
-import com.seo92js.news_alpha_backend.domain.signal.repository.SignalRepository;
 import com.seo92js.news_alpha_backend.domain.stock.repository.StockKeywordRepository;
 import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportRepository;
 import com.seo92js.news_alpha_backend.domain.stock.repository.StockReportSignalRepository;
@@ -21,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -103,6 +102,27 @@ public class StockService {
     private List<StockKeywordResponse> findKeywordResponses(Long stockId) {
         return stockKeywordRepository.findByStockId(stockId).stream()
                 .map(StockKeywordResponse::from)
+                .toList();
+    }
+
+    /**
+     * 전체 종목의 최신 시그널 레포트 조회
+     */
+    @Transactional(readOnly = true)
+    public List<StockLatestReportResponse> findLatestReports() {
+        List<StockReport> latestReports = stockReportRepository.findLatestStockReports();
+        if (latestReports.isEmpty()) return List.of();
+
+        List<Long> reportIds = latestReports.stream().map(StockReport::getId).toList();
+        Map<Long, List<StockSignalSummaryResponse>> signalsByStockReportId =
+                stockReportSignalRepository.findSignalSummariesByStockReportIds(reportIds).stream()
+                        .collect(Collectors.groupingBy(StockSignalSummaryResponse::stockReportId));
+
+        return latestReports.stream()
+                .map(report -> StockLatestReportResponse.from(
+                        report,
+                        signalsByStockReportId.getOrDefault(report.getId(), List.of())
+                ))
                 .toList();
     }
 

--- a/src/test/java/com/seo92js/news_alpha_backend/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/com/seo92js/news_alpha_backend/domain/stock/service/StockServiceTest.java
@@ -64,13 +64,13 @@ class StockServiceTest {
 
         List<StockSignalSummaryResponse> signals = List.of(
                 new StockSignalSummaryResponse(
-                        101L, "로보택시 기대감 재점화", "최근 기사 급증",
+                        stockReport.getId(), 101L, "로보택시 기대감 재점화", "최근 기사 급증",
                         SignalEventType.PRODUCT, SignalSentiment.POSITIVE, 78,
                         "로보택시 기대가 투자 심리에 영향을 줄 수 있습니다.",
                         88.2, 6, LocalDateTime.of(2026, 5, 7, 9, 0)
                 ),
                 new StockSignalSummaryResponse(
-                        102L, "일론 머스크 발언 영향", "변동성 확대",
+                        stockReport.getId(), 102L, "일론 머스크 발언 영향", "변동성 확대",
                         SignalEventType.MANAGEMENT, SignalSentiment.MIXED, 70,
                         "CEO 발언에 따른 변동성 확대 여부를 확인해야 합니다.",
                         81.5, 4, LocalDateTime.of(2026, 5, 7, 8, 30)


### PR DESCRIPTION
홈 화면에서 쓸 관심 종목별 최신 리포트 조회하는 로직 추가함
당일 작성 리포트 조회로 하려다가 전에 테스트로 만든 리포트가 안보여서 최신으로 했음